### PR TITLE
add test for MathJax/MathJax#814 

### DIFF
--- a/testsuite/UI/issue814.html
+++ b/testsuite/UI/issue814.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <title>TeX strings in annotation</title>
+    <!-- Copyright (c) 2014 MathJax Consortium
+         License: Apache License 2.0 -->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="text/javascript" src="../header.js"></script>
+    <script type="text/javascript" src="../scriptTests.js"></script>
+    <script type="text/javascript">
+      function preMathJax() {
+        gConfigObject.menuSettings = {semantics: true};
+        gConfigObject.extensions.push("toMathML.js");
+      }
+
+      function getTestCases() {
+        var jax = MathJax.Hub.getAllJax()[0];
+        return [
+          newScriptReftestResult("Annotation elements in Show MathML source",
+            jax.root.toMathML('',jax).indexOf("</annotation>") > -1),
+        ];
+      }
+    </script>
+  </head>
+
+  <body>
+
+    <!--
+        See issue 814 (expose annotations in toMathML() )
+        https://github.com/mathjax/MathJax/issues/814-->
+    <div>
+      \( x+1 \)
+    </div>
+
+  </body>
+</html>

--- a/testsuite/UI/reftest.list
+++ b/testsuite/UI/reftest.list
@@ -5,5 +5,6 @@ include zoom/reftest.list
 script show-source-1.html
 script show-source-2.html
 script issue685.html
+script issue814.html?semantics=true
 script issue912.html
 script issue935.html?semantics=true


### PR DESCRIPTION
This checks for annotation elements in toMathML output.

Should we add a test to check if the menu item triggers annotations correctly?
