### PR TITLE
add test for MathJax/MathJax#898 

### DIFF
--- a/testsuite/MathMLToDisplay/Characters/issue898-1.html
+++ b/testsuite/MathMLToDisplay/Characters/issue898-1.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <title>SVG output of space characters</title>
+    <!-- Copyright (c) 2015 MathJax Consortium
+         License: Apache License 2.0 -->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="text/javascript" src="../../header.js"></script>
+    <script type="text/javascript">
+      function preMathJax() {
+        gMaxErrorSignals["SVG Jax - unknown char"] = 0;
+      }
+    </script>
+  </head>
+
+  <body>
+
+    <!--
+        Test if SVG output handles space characters correctly
+        See issue 898
+        https://github.com/mathjax/MathJax/issues/898 -->
+    <div>
+      \( a &#x2000; b \)
+      \( a &#x2001; b \)
+      \( a &#x2002; b \)
+      \( a &#x2003; b \)
+      \( a &#x2004; b \)
+      \( a &#x2005; b \)
+      \( a &#x2006; b \)
+      \( a &#x2009; b \)
+      \( a &#x200A; b \)
+      \( a &#x200B; b \)
+    </div>
+
+  </body>
+</html>

--- a/testsuite/MathMLToDisplay/Characters/issue898-2.html
+++ b/testsuite/MathMLToDisplay/Characters/issue898-2.html
@@ -9,25 +9,22 @@
     <script type="text/javascript" src="../../scriptTests.js"></script>
     <script type="text/javascript">
       function getTestCases() {
-        var texts = document.getElementsByTagName('text');
-        var check1 = (texts.length === 0) ;        
         var svgs = document.getElementsByTagName('svg');
-        var check2 = true;
-        for (i=0;i<svgs.length;i++){
+        var check1 = true;
+        for (var i=0; i < svgs.length; i++){
           if (svgs[i].innerHTML.indexOf('font-style=""')>-1){
-            check2 = false;
+            check1 = false; break;
           }
         }
-        var check3 = true;
-        for (i=0;i<svgs.length;i++){
+        var check2 = true;
+        for (var i=0; i < svgs.length; i++){
           if (svgs[i].innerHTML.indexOf('font-weight=""')>-1){
-            check3 = false;
+            check2 = false; break;
           }
         }
         return [
-          newScriptReftestResult("SVG output supports U+2000 to U+200B", check1),
-          newScriptReftestResult("SVG output does not generate empty font-style attributes", check2),
-          newScriptReftestResult("SVG output does not generate empty font-weight attributes", check3)
+          newScriptReftestResult("SVG output does not generate empty font-style attributes for unkown characters", check1),
+          newScriptReftestResult("SVG output does not generate empty font-weight attributes for unkown characters", check2)
         ];
       }
     </script>
@@ -40,16 +37,7 @@
         See issue 898
         https://github.com/mathjax/MathJax/issues/898 -->
     <div>
-      \( a &#x2000; b \)
-      \( a &#x2001; b \)
-      \( a &#x2002; b \)
-      \( a &#x2003; b \)
-      \( a &#x2004; b \)
-      \( a &#x2005; b \)
-      \( a &#x2006; b \)
-      \( a &#x2009; b \)
-      \( a &#x200A; b \)
-      \( a &#x200B; b \)
+      \( &#x0972; \)
     </div>
 
   </body>

--- a/testsuite/MathMLToDisplay/Characters/issue898-2.html
+++ b/testsuite/MathMLToDisplay/Characters/issue898-2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
   <head>
-    <title>SVG output of space characters</title>
+    <title>SVG output of unkown characters</title>
     <!-- Copyright (c) 2015 MathJax Consortium
          License: Apache License 2.0 -->
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -9,19 +9,9 @@
     <script type="text/javascript" src="../../scriptTests.js"></script>
     <script type="text/javascript">
       function getTestCases() {
-        var svgs = document.getElementsByTagName('svg');
-        var check1 = true;
-        for (var i=0; i < svgs.length; i++){
-          if (svgs[i].innerHTML.indexOf('font-style=""')>-1){
-            check1 = false; break;
-          }
-        }
-        var check2 = true;
-        for (var i=0; i < svgs.length; i++){
-          if (svgs[i].innerHTML.indexOf('font-weight=""')>-1){
-            check2 = false; break;
-          }
-        }
+        var svg = document.getElementsByTagName('svg')[0];
+        var check1 = (svg.innerHTML.indexOf('font-style=""') > -1);
+        var check2 = (svg.innerHTML.indexOf('font-weight=""') > -1);        }
         return [
           newScriptReftestResult("SVG output does not generate empty font-style attributes for unkown characters", check1),
           newScriptReftestResult("SVG output does not generate empty font-weight attributes for unkown characters", check2)
@@ -33,7 +23,7 @@
   <body>
 
     <!--
-        Test if SVG output handles space characters correctly
+        Test if SVG output for unkown characters is valid SVG
         See issue 898
         https://github.com/mathjax/MathJax/issues/898 -->
     <div>

--- a/testsuite/MathMLToDisplay/Characters/issue898.html
+++ b/testsuite/MathMLToDisplay/Characters/issue898.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <title>SVG output of space characters</title>
+    <!-- Copyright (c) 2015 MathJax Consortium
+         License: Apache License 2.0 -->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="text/javascript" src="../../header.js"></script>
+    <script type="text/javascript" src="../../scriptTests.js"></script>
+    <script type="text/javascript">
+      function getTestCases() {
+        var texts = document.getElementsByTagName('text');
+        var check1 = (texts.length === 0) ;        
+        var svgs = document.getElementsByTagName('svg');
+        var check2 = true;
+        for (i=0;i<svgs.length;i++){
+          if (svgs[i].innerHTML.indexOf('font-style=""')>-1){
+            check2 = false;
+          }
+        }
+        var check3 = true;
+        for (i=0;i<svgs.length;i++){
+          if (svgs[i].innerHTML.indexOf('font-weight=""')>-1){
+            check3 = false;
+          }
+        }
+        return [
+          newScriptReftestResult("SVG output supports U+2000 to U+200B", check1),
+          newScriptReftestResult("SVG output does not generate empty font-style attributes", check2),
+          newScriptReftestResult("SVG output does not generate empty font-weight attributes", check3)
+        ];
+      }
+    </script>
+  </head>
+
+  <body>
+
+    <!--
+        Test if SVG output handles space characters correctly
+        See issue 898
+        https://github.com/mathjax/MathJax/issues/898 -->
+    <div>
+      \( a &#x2000; b \)
+      \( a &#x2001; b \)
+      \( a &#x2002; b \)
+      \( a &#x2003; b \)
+      \( a &#x2004; b \)
+      \( a &#x2005; b \)
+      \( a &#x2006; b \)
+      \( a &#x2009; b \)
+      \( a &#x200A; b \)
+      \( a &#x200B; b \)
+    </div>
+
+  </body>
+</html>

--- a/testsuite/MathMLToDisplay/Characters/reftest.list
+++ b/testsuite/MathMLToDisplay/Characters/reftest.list
@@ -34,3 +34,4 @@ require(STIX) != issue222.html issue222-ref.html
 require(STIX) == issue697.html issue697-ref.html
 script issue826-1.html
 require(!NativeMML) script issue826-2.html
+require(SVG) script issue898.html

--- a/testsuite/MathMLToDisplay/Characters/reftest.list
+++ b/testsuite/MathMLToDisplay/Characters/reftest.list
@@ -34,4 +34,5 @@ require(STIX) != issue222.html issue222-ref.html
 require(STIX) == issue697.html issue697-ref.html
 script issue826-1.html
 require(!NativeMML) script issue826-2.html
-require(SVG) script issue898.html
+require(SVG) script issue898-1.html
+require(SVG) script issue898-2.html


### PR DESCRIPTION
check SVG output supports space characters; check SVG output creates only non-emtpy font-style and font-weight attributes
